### PR TITLE
Add test framework with example test

### DIFF
--- a/include/kernel_tests.h
+++ b/include/kernel_tests.h
@@ -1,12 +1,18 @@
 #ifndef _KERNEL_TESTS_H
 #define _KERNEL_TESTS_H
 
+#include "test_framework.h"
+
 extern "C" void heapTests();
+void runKernelTests();
 void event_loop_tests();
 void queue_test();
 void frame_alloc_tests();
 void test_frame_alloc_simple();
 void test_frame_alloc_multiple();
 void test_pin_frame();
+
+// Test Suite Declarations.
+test_suite_stats basic_test_suite(bool);
 
 #endif /*_KERNEL_TESTS_H */

--- a/include/test_framework.h
+++ b/include/test_framework.h
@@ -36,7 +36,7 @@ struct suite_stats {
 } typedef test_suite_stats;
 
 #define BEGIN_TEST_SUITE(suite_name) \
-    test_suite_stats suite_name(bool verbose) { \
+    test_suite_stats test_suite_##suite_name(bool verbose) { \
         test_suite_stats suite_stats; \
         suite_stats.passed = 0; \
         suite_stats.total = 0; \
@@ -60,11 +60,14 @@ struct suite_stats {
     suite_stats.total++; \
     if (verbose) printf("Passed Test: %s\n", #test_function);
 
-#define RUN_TEST_SUITE(suite_function, verbose) \
-    printf("Running Test Suite %s:\n", #suite_function); \
-    suite_results = suite_function(verbose); \
+#define DECLARE_TEST_SUITE(suite_name) \
+    test_suite_stats test_suite_##suite_name(bool verbose);
+
+#define RUN_TEST_SUITE(suite_name, verbose) \
+    printf("Running Test Suite '%s':\n", #suite_name); \
+    suite_results = test_suite_##suite_name(verbose); \
     printf("Passed %d / %d tests.\n", suite_results.passed, suite_results.total); \
-    printf("Finished Running Suite: %s\n\n\n", #suite_function); \
+    printf("Finished Running Suite '%s'\n\n\n", #suite_name); \
 
 // Use do-while loop to avoid pre-processor expansion issues
 #define EXPECT_TRUE(condition, msg) do {                    \

--- a/include/test_framework.h
+++ b/include/test_framework.h
@@ -12,7 +12,7 @@ Add this line in runKernelTests()::kernel_tests.cpp
     RUN_TEST_SUITE(basic_test_suite, true) // verbose mode = true.
 
 tests/test_suites.h: Declare test suite.
-   test_suite_stats basic_test_suite(bool); 
+    DECLARE_TEST_SUITE(basic_test_suite);
 
 my_test_suite.cpp: Define test suite.
     #include "tests/test_suites.h"
@@ -26,7 +26,7 @@ my_test_suite.cpp: Define test suite.
 
     // Define test suite (put at the end of the file).
     BEGIN_TEST_SUITE(basic_test_suite)
-        TEST_CASE(test_should_pass)
+        ADD_TEST(test_should_pass)
     END_TEST_SUITE
 */
 

--- a/include/test_framework.h
+++ b/include/test_framework.h
@@ -1,0 +1,85 @@
+/* test_framework.h */
+#ifndef TEST_FRAMEWORK_H_
+#define TEST_FRAMEWORK_H_
+
+#include "printf.h"
+#include "libk.h"
+
+/*
+To add a test suite, do the following:
+
+Add this line in runKernelTests()::kernel_tests.cpp
+    RUN_TEST_SUITE(basic_test_suite, true) // verbose mode = true.
+
+tests/test_suites.h: Declare test suite.
+   test_suite_stats basic_test_suite(bool); 
+
+my_test_suite.cpp: Define test suite.
+    #include "tests/test_suites.h"
+
+    // Define test cases.
+    TEST_CASE(should_pass) {
+        EXPECT_TRUE(1 == 1, "They should be equal.");
+        ASSERT_TRUE(5 != 4, "Shouldn't be equal.");
+        return true;
+    }
+
+    // Define test suite (put at the end of the file).
+    BEGIN_TEST_SUITE(basic_test_suite)
+        TEST_CASE(test_should_pass)
+    END_TEST_SUITE
+*/
+
+struct suite_stats {
+    int passed;
+    int total;
+} typedef test_suite_stats;
+
+#define BEGIN_TEST_SUITE(suite_name) \
+    test_suite_stats suite_name(bool verbose) { \
+        test_suite_stats suite_stats; \
+        suite_stats.passed = 0; \
+        suite_stats.total = 0; \
+        do  /* Begin user test case block */ {           \
+            /* User's test cases go here */               \
+
+#define END_TEST_SUITE \
+    } while(0); \
+    return suite_stats; \
+    }
+
+#define TEST_CASE(name) \
+    bool test_case_##name() \
+
+#define ADD_TEST(test_function) \
+   if (test_case_##test_function()) { \
+        suite_stats.passed++; \
+    } else if (verbose) { \
+        printf("Failed Test: %s\n", #test_function); \
+    } \
+    suite_stats.total++; \
+    if (verbose) printf("Passed Test: %s\n", #test_function);
+
+#define RUN_TEST_SUITE(suite_function, verbose) \
+    printf("Running Test Suite %s:\n", #suite_function); \
+    suite_results = suite_function(verbose); \
+    printf("Passed %d / %d tests.\n", suite_results.passed, suite_results.total); \
+    printf("Finished Running Suite: %s\n\n\n", #suite_function); \
+
+// Use do-while loop to avoid pre-processor expansion issues
+#define EXPECT_TRUE(condition, msg) do {                    \
+    if (!(condition)) {                                     \
+        printf("Failed: %s, (File: %s, Line: %d)\n",         \
+                (msg), __FILE__, __LINE__);                  \
+    }                                                       \
+} while(0)
+
+#define ASSERT_TRUE(condition, msg) do {                    \
+    if (!(condition)) {                                     \
+        printf("Failed: %s, (File: %s, Line: %d)\n",         \
+                (msg), __FILE__, __LINE__);                  \
+        K::assert(0, "ASSERTION_FAILED!!!");                \
+    }                                                       \
+} while(0)
+
+#endif /* TEST_FRAMEWORK_H_ */

--- a/include/tests/test_suites.h
+++ b/include/tests/test_suites.h
@@ -3,6 +3,6 @@
 
 #include "test_framework.h"
 
-test_suite_stats basic_test_suite(bool verbose);
+DECLARE_TEST_SUITE(basic_test_suite);
 
 #endif

--- a/include/tests/test_suites.h
+++ b/include/tests/test_suites.h
@@ -1,0 +1,8 @@
+#ifndef TEST_SUITES_H_
+#define TEST_SUITES_H_
+
+#include "test_framework.h"
+
+test_suite_stats basic_test_suite(bool verbose);
+
+#endif

--- a/src/basic_test_suite.cpp
+++ b/src/basic_test_suite.cpp
@@ -1,0 +1,14 @@
+#include "tests/test_suites.h"
+
+// Define test cases.
+TEST_CASE(should_pass) {
+    EXPECT_TRUE(1 == 1, "They should be equal.");
+    ASSERT_TRUE(5 != 4, "Shouldn't be equal.");
+    return true;
+}
+
+// Define test suite (put at the end of the file).
+BEGIN_TEST_SUITE(basic_test_suite)
+    ADD_TEST(should_pass)
+END_TEST_SUITE
+

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -67,10 +67,8 @@ extern char _frame_table_start[];
 
 extern "C" void kernel_main()
 {
-    heapTests();
-    event_loop_tests();
-    queue_test();
-    frame_alloc_tests();
+
+    runKernelTests();
 }
 
 extern char __heap_start[];

--- a/src/kernel_tests.cpp
+++ b/src/kernel_tests.cpp
@@ -8,6 +8,26 @@
 #include "event_loop.h"
 #include "frame.h"
 
+#include "tests/test_suites.h"
+
+/* PUT ALL UNIT TEST SUITES HERE.
+
+Structure should be as follows:
+- Within 'runKernelTests', each function called corresponds to a test suite
+- Each test suite should be defined in it's own file.
+
+*/
+void runKernelTests() {
+    test_suite_stats suite_results; // DO NOT REMOVE.
+
+    // Put your test suites here!
+    heapTests();
+    event_loop_tests();
+    queue_test();
+    frame_alloc_tests();
+    RUN_TEST_SUITE(basic_test_suite, true /* verbose */)
+}
+
 void test_new_delete_basic()
 {
     printf("Test 1: Basic Allocation and Deletion\n");


### PR DESCRIPTION
#24

not sure if this is too annoying to use, but i think it's nice once it's set up. The annoying part IMO is adding test suites which only needs to be done once per suite.

You've gotta do some stuff to register each test suite:

```cpp
// runKernelTests() inside kernel_tests.cpp    
RUN_TEST_SUITE(basic_test_suite, true /* verbose mode */)

// tests/test_suites.h: Declare test suite.
DECLARE_TEST_SUITE(basic_test_suite);
```
After test suite is set up, adding tests is straightforward.
```cpp
// my_test_suite.cpp: Define test suite.
#include "tests/test_suites.h"

// Define test cases (return true / false to indicate pass / fail).
TEST_CASE(should_pass) {
    EXPECT_TRUE(1 == 1, "They should be equal."); // won't crash when condition fails
    ASSERT_TRUE(5 != 4, "Shouldn't be equal."); // will crash when condition fails
    return true;
}

// Define test suite (put at the end of the file).
BEGIN_TEST_SUITE(basic_test_suite)
    ADD_TEST(should_pass)
    ... add as many as you want
END_TEST_SUITE
```

Running it in verbose mode (in `runKernelTests()::kernel_tests.cpp`) tells you which tests pass / fail:
```
Running Test Suite 'basic_test_suite':
Passed Test: should_pass
Passed 1 / 1 tests.
Finished Running Suite 'basic_test_suite'
```
