### PR TITLE
Switch To EL0

### DIFF
--- a/include/event.h
+++ b/include/event.h
@@ -16,12 +16,26 @@
 // --event.h--
 //-------------
 
-extern void threadsInit();
-
-extern void stop();
-extern void yield();
-
 struct cpu_context {
+    unsigned long int x0;
+    unsigned long int x1;
+    unsigned long int x2;
+    unsigned long int x3;
+    unsigned long int x4;
+    unsigned long int x5;
+    unsigned long int x6;
+    unsigned long int x7;
+    unsigned long int x8;
+    unsigned long int x9;
+    unsigned long int x10;
+    unsigned long int x11;
+    unsigned long int x12;
+    unsigned long int x13;
+    unsigned long int x14;
+    unsigned long int x15;
+    unsigned long int x16;
+    unsigned long int x17;
+    unsigned long int x18;
     unsigned long int x19;
     unsigned long int x20;
     unsigned long int x21;
@@ -32,15 +46,15 @@ struct cpu_context {
     unsigned long int x26;
     unsigned long int x27;
     unsigned long int x28;
-    unsigned long int fp;
+    unsigned long int x29;
+    unsigned long int x30;
     unsigned long int sp;
     unsigned long int pc;
+    unsigned long int spsr;
 };
 
 struct TCB {
-    TCB* next;
-    PCB* pcb;
-    bool wasDisabled = false;  // previous interrupt state
+    TCB* next = nullptr;
     bool kernel_event = true;
     virtual void run() = 0;  // Abstract/virtual function that must be overridden
     virtual ~TCB() {};       // Allows child classes to be deleted
@@ -51,64 +65,23 @@ struct CPU_Queues {
 
 extern PerCPU<CPU_Queues> readyQueue;
 
-extern void event_loop(LockedQueue<TCB, SpinLock>* q, /*ISL*/ SpinLock* isl);  // generalized yield
-extern void entry();         // have a thread start work
-extern void restoreState();  // restore state post context switch
-extern void clearZombies();  // delete threads that have called stop.
+extern void event_loop();
+extern void enter_user_space(struct UserTCB* tcb);
+extern void save_user_context(struct UserTCB* tcb, uint64_t* regs);
 
-// template <typename Work>
 struct UserTCB : public TCB {
     cpu_context context;
-    Function<void()> w;
-    alignas(16) uint64_t stack[2048];  // Ensure proper 16-byte alignment
+    PCB* pcb = nullptr;
+    Function<void(UserTCB*)> w;
     bool use_pt = false;
-    template <typename lambda>
-    UserTCB(lambda w) : w(w) {
-        context.x19 = 0;
-        context.x20 = 0;
-        context.x21 = 0;
-        context.x22 = 0;
-        context.x23 = 0;
-        context.x24 = 0;
-        context.x25 = 0;
-        context.x26 = 0;
-        context.x27 = 0;
-        context.x28 = 0;
-        context.sp = (uint64_t)&stack[2048];  // Stack grows downward
-        context.pc = (uint64_t)&entry;        // Function to execute when the thread starts
+    UserTCB() : w(enter_user_space) {
+        context.sp = 0;
+        context.pc = 0;
         kernel_event = false;
     }
 
     void run() override {
-        w();
-    }
-};
-
-template <typename T>
-struct UserValue : public TCB {
-    cpu_context context;
-    Function<void(T)> w;
-    T value;
-    alignas(16) uint64_t stack[2048];  // Ensure proper 16-byte alignment
-    template <typename lambda>
-    UserValue(lambda w, T value) : w(w), value(value) {
-        context.x19 = 0;
-        context.x20 = 0;
-        context.x21 = 0;
-        context.x22 = 0;
-        context.x23 = 0;
-        context.x24 = 0;
-        context.x25 = 0;
-        context.x26 = 0;
-        context.x27 = 0;
-        context.x28 = 0;
-        context.sp = (uint64_t)&stack[2048];  // Stack grows downward
-        context.pc = (uint64_t)&entry;        // Function to execute when the thread starts
-        kernel_event = false;
-    }
-
-    void run() override {
-        w(value);
+        w(this);
     }
 };
 
@@ -138,24 +111,12 @@ struct EventValue : public TCB {
     }
 };
 
-extern LockedQueue<TCB, SpinLock> zombieQ;
-
-template <typename lambda>
-inline void user_thread(lambda work) {
-    auto tcb = new UserTCB(work);
-    readyQueue.mine().queues[1].add(tcb);
-}
-
-template <typename T>
-inline void user_thread(Function<void(T)> work, T value) {
-    auto tcb = new UserValue<T>(work, value);
-    readyQueue.mine().queues[1].add(tcb);
-}
-
-template <typename lambda>
-inline void user_thread(lambda work, int priority) {
-    auto tcb = new UserTCB(work);
+inline void queue_user_tcb(UserTCB* tcb, int priority) {
     readyQueue.mine().queues[priority].add(tcb);
+}
+
+inline void queue_user_tcb(UserTCB* tcb) {
+    readyQueue.mine().queues[1].add(tcb);
 }
 
 template <typename lambda>
@@ -194,6 +155,8 @@ inline void create_event_core(
     readyQueue.forCPU(core).queues[1].add(tcb);
 }
 
-TCB* currentTCB(int core);
+void set_return_value(UserTCB* tcb, uint64_t ret_val);
+
+UserTCB* get_running_user_tcb(int core);
 
 #endif

--- a/include/sched.h
+++ b/include/sched.h
@@ -32,6 +32,12 @@ extern "C" void preempt_disable(void);
 extern "C" void preempt_enable(void);
 extern "C" void switch_to(struct task_struct* next);
 extern "C" void cpu_switch_to(struct task_struct* prev, struct task_struct* next);
+extern "C" void user_entry(cpu_context* context);
+extern "C" void save_user_state(cpu_context* context);
+extern "C" void load_user_context(cpu_context* context);
+extern "C" uint64_t get_sp_el0();
+extern "C" uint64_t get_elr_el1();
+extern "C" uint64_t get_spsr_el1();
 
 #define INIT_TASK {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, 0, 1, 0}
 

--- a/include/trap_frame.h
+++ b/include/trap_frame.h
@@ -1,0 +1,12 @@
+#ifndef _TRAP_FRAME_H
+#define _TRAP_FRAME_H
+
+#include "stdint.h"
+
+struct trap_frame {
+    uint64_t X[31];
+};
+
+typedef trap_frame SyscallFrame;
+
+#endif /* _TRAP_FRAME_H */

--- a/include/utils.h
+++ b/include/utils.h
@@ -9,6 +9,7 @@ extern "C" int atomic_exchange(int* ptr, int new_value);
 extern "C" void release_lock(int* ptr, int new_value);
 extern "C" unsigned long get_el();
 extern "C" unsigned long get_sp();
+extern "C" void set_sp_and_jump(uint64_t sp, void (*entry)());
 
 extern "C" void monitor(long addr);
 extern "C" void outb(int port, int val);

--- a/src/boot.S
+++ b/src/boot.S
@@ -148,7 +148,7 @@ setup_el1_for_secondary:
 	ldp	x28, x29, [sp, #16 * 14]
 	ldr	x30, [sp, #16 * 15] 
 	add	sp, sp, #S_FRAME_SIZE		
-	eret
+	ret
 	.endm
 
 secondary_kernel_main:
@@ -229,34 +229,25 @@ b       exc_handler
 .endm
 
 synchronous_el0:
+    kernel_entry
+    mov x0, sp
+
     mrs     x1, esr_el1         // ESR_EL1 has EC in bits [31:26]
     lsr     x2, x1, #26         // x2 = EC = ESR_EL1[31:26]
     cmp     x2, #0x15           // 0x15 = SVC from EL0
     b.ne    not_syscall         // if not SVC, go handle as exception
-
+    
     // It's an SVC -> syscall
-    sub	sp, sp, #S_FRAME_SIZE
-	stp	x0, x1, [sp, #16 * 0]
-	stp	x2, x3, [sp, #16 * 1]
-	stp	x4, x5, [sp, #16 * 2]
-	stp	x6, x7, [sp, #16 * 3]
-	stp	x8, x9, [sp, #16 * 4]
-	stp	x10, x11, [sp, #16 * 5]
-	stp	x12, x13, [sp, #16 * 6]
-	stp	x14, x15, [sp, #16 * 7]
-	stp	x16, x17, [sp, #16 * 8]
-	stp	x18, x19, [sp, #16 * 9]
-	stp	x20, x21, [sp, #16 * 10]
-	stp	x22, x23, [sp, #16 * 11]
-	stp	x24, x25, [sp, #16 * 12]
-	stp	x26, x27, [sp, #16 * 13]
-	stp	x28, x29, [sp, #16 * 14]
-	str	x30, [sp, #16 * 15] 
-    mov x0, sp
     bl syscall_handler
     kernel_exit                 // returns to user via eret
 
 not_syscall:
+    lsr     x2, x1, #26         // x2 = EC = ESR_EL1[31:26]
+    cmp x2, #0x24               // 0x24 = Data Abort
+    b.ne not_data_abort
+    bl page_fault_handler
+   
+not_data_abort:
     mov     x0, #0              // you could pass reason info here if needed
     handle_exception            // handle exception (which jumps to exc_handler)
 
@@ -317,8 +308,9 @@ serror_el1:
     handle_exception
     
 synchronous_el0_64:
-    mov     x0, #0
-    handle_exception
+    b synchronous_el0
+    // mov     x0, #0
+    // handle_exception
 
 irq_el0_64: 
 	kernel_entry 

--- a/src/boot.S
+++ b/src/boot.S
@@ -130,7 +130,29 @@ setup_el1_for_secondary:
 	str	x30, [sp, #16 * 15] 
 	.endm
 
-	.macro	kernel_exit
+.macro	kernel_exit
+	ldp	x0, x1, [sp, #16 * 0]
+	ldp	x2, x3, [sp, #16 * 1]
+	ldp	x4, x5, [sp, #16 * 2]
+	ldp	x6, x7, [sp, #16 * 3]
+	ldp	x8, x9, [sp, #16 * 4]
+	ldp	x10, x11, [sp, #16 * 5]
+	ldp	x12, x13, [sp, #16 * 6]
+	ldp	x14, x15, [sp, #16 * 7]
+	ldp	x16, x17, [sp, #16 * 8]
+	ldp	x18, x19, [sp, #16 * 9]
+	ldp	x20, x21, [sp, #16 * 10]
+	ldp	x22, x23, [sp, #16 * 11]
+	ldp	x24, x25, [sp, #16 * 12]
+	ldp	x26, x27, [sp, #16 * 13]
+	ldp	x28, x29, [sp, #16 * 14]
+	ldr	x30, [sp, #16 * 15] 
+	add	sp, sp, #S_FRAME_SIZE		
+	eret
+	.endm
+
+
+.macro	kernel_exit_el1
 	ldp	x0, x1, [sp, #16 * 0]
 	ldp	x2, x3, [sp, #16 * 1]
 	ldp	x4, x5, [sp, #16 * 2]
@@ -292,12 +314,12 @@ synchronous_el1:
 	str	x30, [sp, #16 * 15] 
     mov x0, sp
     bl syscall_handler
-    kernel_exit                 // returns to user via eret
+    kernel_exit_el1                 // returns to user via eret
 
 irq_el1: 
 	kernel_entry 
 	bl	handle_irq
-	kernel_exit 
+	kernel_exit_el1 
 
 fiq_el1:
     mov     x0, #2

--- a/src/elf_loader.cpp
+++ b/src/elf_loader.cpp
@@ -11,7 +11,7 @@
 
 #define ERROR(msg...) printf(msg);
 
-#define MAP_FAILED (void*)-1
+#define MAP_FAILED (void *)-1
 #define ELF_RELOC_ERR -1
 
 LoadedLibrary *g_loaded_libs = nullptr;
@@ -38,45 +38,44 @@ bool elf_check_file(Elf64_Ehdr *hdr) {
 }
 
 bool elf_check_supported(Elf64_Ehdr *hdr) {
-	if(!elf_check_file(hdr)) {
-		ERROR("Invalid ELF File.\n");
-		return false;
-	}
-	if(hdr->e_ident[EI_CLASS] != ELFCLASS64) {
-		ERROR("Unsupported ELF File Class.\n");
-		return false;
-	}
-	if(hdr->e_ident[EI_DATA] != ELFDATA2LSB) {
-		ERROR("Unsupported ELF File byte order.\n");
-		return false;
-	}
-	if(hdr->e_machine != EM_ARM) {
-		ERROR("Unsupported ELF File target.\n");
-		return false;
-	}
-	if(hdr->e_ident[EI_VERSION] != EV_CURRENT) {
-		ERROR("Unsupported ELF File version.\n");
-		return false;
-	}
-	if(hdr->e_type != ET_REL && hdr->e_type != ET_EXEC && hdr->e_type != ET_DYN) {
-		ERROR("Unsupported ELF File type. %d\n", hdr->e_type);
-		return false;
-	}
-	return true;
+    if (!elf_check_file(hdr)) {
+        ERROR("Invalid ELF File.\n");
+        return false;
+    }
+    if (hdr->e_ident[EI_CLASS] != ELFCLASS64) {
+        ERROR("Unsupported ELF File Class.\n");
+        return false;
+    }
+    if (hdr->e_ident[EI_DATA] != ELFDATA2LSB) {
+        ERROR("Unsupported ELF File byte order.\n");
+        return false;
+    }
+    if (hdr->e_machine != EM_ARM) {
+        ERROR("Unsupported ELF File target.\n");
+        return false;
+    }
+    if (hdr->e_ident[EI_VERSION] != EV_CURRENT) {
+        ERROR("Unsupported ELF File version.\n");
+        return false;
+    }
+    if (hdr->e_type != ET_REL && hdr->e_type != ET_EXEC && hdr->e_type != ET_DYN) {
+        ERROR("Unsupported ELF File type. %d\n", hdr->e_type);
+        return false;
+    }
+    return true;
 }
 
-Elf64_Shdr *find_section(Elf64_Ehdr* hdr, const char* name) {
-	Elf64_Shdr *shdr = elf_sheader(hdr);
-	for(int i = 0; i < hdr->e_shnum; i++) {
-		
-		Elf64_Shdr *section = &shdr[i];
-		Elf64_Shdr *shstrndx = elf_section(hdr, hdr->e_shstrndx);
-		const char *cname = (const char *)hdr + shstrndx->sh_offset + section->sh_name;
-		if (K::strcmp(name, cname) == 0) {
-			return section;
-		}
-	}
-	return nullptr;
+Elf64_Shdr *find_section(Elf64_Ehdr *hdr, const char *name) {
+    Elf64_Shdr *shdr = elf_sheader(hdr);
+    for (int i = 0; i < hdr->e_shnum; i++) {
+        Elf64_Shdr *section = &shdr[i];
+        Elf64_Shdr *shstrndx = elf_section(hdr, hdr->e_shstrndx);
+        const char *cname = (const char *)hdr + shstrndx->sh_offset + section->sh_name;
+        if (K::strcmp(name, cname) == 0) {
+            return section;
+        }
+    }
+    return nullptr;
 }
 
 void *elf_lookup_symbol(Elf64_Ehdr *hdr, const char *name) {

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -77,17 +77,16 @@ extern char _frame_table_start[];
 #define frame_table_start ((uintptr_t)_frame_table_start)
 
 extern "C" void kernel_main() {
-    // queue_test();
     printf("All tests passed\n");
-    // heapTests();
-    // event_loop_tests();
-    // hash_test();
-    // frame_alloc_tests();
-    // user_paging_tests();
-    // blocking_atomic_tests();
-    // ramfs_tests();
-    // sdioTests();
-    // ring_buffer_tests();
+    heapTests();
+    event_loop_tests();
+    hash_test();
+    frame_alloc_tests();
+    user_paging_tests();
+    blocking_atomic_tests();
+    ramfs_tests();
+    sdioTests();
+    ring_buffer_tests();
     elf_load_test();
     // partitionTests(); // Won't pass on QEMU without a formatted SD card image so I'm commenting
     // it out.
@@ -146,7 +145,6 @@ extern "C" void primary_kernel_init() {
     smpInitDone = true;
     // with data cache on, we must write the boolean back to memory to allow other cores to see it.
     clean_dcache_line(&smpInitDone);
-    threadsInit();
     init_page_cache();
     wake_up_cores();
     mergeCores();
@@ -160,15 +158,14 @@ void mergeCores() {
 
     if (number_awake == CORE_COUNT) {
         create_event([] { kernel_main(); });
-        user_thread([] { printf("i do nothing2\n"); });
     }
 
     // Uncomment to run snake
     // if(getCoreID() == 0){
     //     printf("init_snake() + keyboard_loop();\n");
-    //     user_thread(init_snake);
-    //     user_thread(keyboard_loop);
+    //     create_event(init_snake);
+    //     create_event(keyboard_loop);
     // }
-    stop();
+    event_loop();
     printf("PANIC I should not go here\n");
 }

--- a/src/kernel_tests.cpp
+++ b/src/kernel_tests.cpp
@@ -527,7 +527,7 @@ void blocking_atomic_tests() {
 
 void elf_load_test() {
     printf("start elf_load tests\n");
-    int elf_index = get_ramfs_index("temp.elf");
+    int elf_index = get_ramfs_index("user_prog");
     PCB* pcb = new PCB;
     const int sz = ramfs_size(elf_index);
     char* buffer = (char*)kmalloc(sz);
@@ -577,6 +577,7 @@ void elf_load_test() {
     });
     tcb->pcb = pcb;
     tcb->context.pc = (uint64_t)new_pc;
+    tcb->context.x30 = (uint64_t)new_pc; /* this just to repeat the user prog again and again*/
     printf("%x this is pc\n", tcb->context.pc);
     tcb->use_pt = true;
     sema->down([=]() {

--- a/src/page_fault.cpp
+++ b/src/page_fault.cpp
@@ -10,6 +10,10 @@
 // #define ACCESS_FLAG_FAULT 2
 // #define PERMISSION_FAULT 3
 
+#include "event.h"
+#include "printf.h"
+#include "trap_frame.h"
+
 // void handle_page_fault(int fault_el, int type, int table_level,  unsigned long far, UserTCB* tcb)
 // {
 
@@ -95,3 +99,10 @@
 //     });
 //     return;
 // }
+
+extern "C" void page_fault_handler(trap_frame* trap_frame) {
+    UserTCB* tcb = get_running_user_tcb(getCoreID());
+    save_user_context(tcb, &trap_frame->X[0]);
+
+    printf("in data abort handler\n");
+}

--- a/src/sched.S
+++ b/src/sched.S
@@ -55,3 +55,48 @@ load_context:
 	ldr	x30, [x8]
 	mov	sp, x9
 	ret
+
+.globl load_user_context
+load_user_context:
+
+	ldr x1, [x0, #8 * 31]
+	ldr x2, [x0, #8 * 32]
+	ldr x3, [x0, #8 * 33]
+
+	msr sp_el0, x1
+	msr elr_el1, x2
+	msr spsr_el1, x3
+
+	ldp	x2, x3, [x0, #16 * 1]
+	ldp	x4, x5, [x0, #16 * 2]
+	ldp	x6, x7, [x0, #16 * 3]
+	ldp	x8, x9, [x0, #16 * 4]
+	ldp	x10, x11, [x0, #16 * 5]
+	ldp	x12, x13, [x0, #16 * 6]
+	ldp	x14, x15, [x0, #16 * 7]
+	ldp	x16, x17, [x0, #16 * 8]
+	ldp	x18, x19, [x0, #16 * 9]
+	ldp	x20, x21, [x0, #16 * 10]
+	ldp	x22, x23, [x0, #16 * 11]
+	ldp	x24, x25, [x0, #16 * 12]
+	ldp	x26, x27, [x0, #16 * 13]
+	ldp	x28, x29, [x0, #16 * 14]
+	ldr	x30, [x0, #16 * 15]
+
+	ldp	x0, x1, [x0, #16 * 0]
+	eret
+
+.globl get_sp_el0
+get_sp_el0:
+	mrs x0, sp_el0
+	ret
+
+.globl get_elr_el1
+get_elr_el1:
+	mrs x0, elr_el1
+	ret
+
+.globl get_spsr_el1
+get_spsr_el1:
+	mrs x0, spsr_el1
+	ret

--- a/src/sys.cpp
+++ b/src/sys.cpp
@@ -4,6 +4,7 @@
 #include "printf.h"
 #include "stdint.h"
 #include "vm.h"
+// #include "trap_frame.h"
 
 // SyscallFrame structure.
 // X[0] - return value
@@ -12,7 +13,7 @@ struct SyscallFrame {
         /* X[0] ... X[5] - arguments
         once function is called, X[0] will be the return value.
         */
-        uint64_t X[30];
+        uint64_t X[31];  // 0 ... 30
     };
 };
 

--- a/src/utils.S
+++ b/src/utils.S
@@ -33,7 +33,6 @@ getCoreID:
 
 .global memset
 .type memset, %function
-
 memset:
     // Arguments: x0 = ptr, x1 = value, x2 = num
     // Return value: x0 (same pointer as input)
@@ -51,3 +50,9 @@ memset_loop:
 
 memset_done:
     ret
+
+.global set_sp_and_jump
+.type set_sp_and_jump, %function
+set_sp_and_jump:
+    mov sp, x0     // Set stack pointer to first argument
+    br  x1         // Branch to function pointer (no return)

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -312,9 +312,9 @@ uint64_t build_page_attributes(LocalPageLocation* local) {
     if ((local->perm & WRITE_PERM) != 0 && (local->perm & EXEC_PERM) == 0) {
         attribute |= (0x1L << 6);
     } else if ((local->perm & WRITE_PERM) != 0 && (local->perm & EXEC_PERM) != 0) {
-        attribute |= (0x0L << 6);
+        attribute |= (0x01L << 6);
     } else {
-        attribute |= (0x0L << 6);
+        attribute |= (0x01L << 6);
     }
 
     attribute |= (0x2L << 2);   // 2nd index in mair


### PR DESCRIPTION
- Makes it so when usertcbs are added to the event loop they run in el0 instead of el1
- pretty big changes to the event loop 
       - no passing in lambdas to userTCBs they come with their own which is the function of loadin their context
       - got rid of the recursion in event loop by smashing the stack whenever it is called
       - these changes also simplified event loop structure by just making every event a call to run
- added a trap_frame file with a struct
- added a way to get to the page fault handler
- changed some permissions issues caused by el0
- whenever you enter the kernel call from a user space trap, call get_running_user_tcb(my_core) to get the current thread that was running
- for blocking user processes store the state of that thread using save_user_context and passing in a pointer to the list of regs and the tcb 
- requeue blocked userThread with queue_user_tcb(UserTCB* tcb)
- if you a user tcb in an syscall/exception/pagefault and need to block, block by:
           - calling get_running_user_tcb to get the tcb
           - save state in there by using save_user_context(tcb, &regs) //wherever you saved the regs so maybe syscallframe
           - call event_loop()
        